### PR TITLE
Handle .env as special data

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ To address this, we have special `derived` values built in by default to
 * `{{_npmignore}}` -> `.npmignore`
 * `{{_npmrc}}` -> `.npmrc`
 * `{{_eslintrc}}` -> `.eslintrc`
+* `{{_env}}` -> `.env`
 
 In your module `templates` directory you should add any / none of these files
 with the following names instead of their real ones:
@@ -347,6 +348,7 @@ templates/
   {{_npmignore}}
   {{_npmrc}}
   {{_eslintrc}}
+  {{_env}}
 ```
 
 As a side note for your git usage, this now means that `templates/.gitignore`

--- a/lib/init.js
+++ b/lib/init.js
@@ -79,6 +79,6 @@ module.exports = function (opts, callback) {
       );
     }
 
-    callback(err);
+    callback(err, results);
   });
 };

--- a/lib/prompts.js
+++ b/lib/prompts.js
@@ -36,7 +36,8 @@ var DEFAULTS = {
     _npmignore: function (data, cb) { cb(null, ".npmignore"); },
     _gitignore: function (data, cb) { cb(null, ".gitignore"); },
     _eslintrc: function (data, cb) { cb(null, ".eslintrc"); },
-    _npmrc: function (data, cb) { cb(null, ".npmrc"); }
+    _npmrc: function (data, cb) { cb(null, ".npmrc"); },
+    _env: function (data, cb) { cb(null, ".env"); }
   }
 };
 
@@ -190,4 +191,3 @@ module.exports._parseOverrides = function (str) {
 // Expose helpers for testing.
 module.exports._DEFAULTS = DEFAULTS;
 module.exports._EXTRA_DATA_FIELDS = EXTRA_DATA_FIELDS;
-

--- a/test/server/spec/lib/templates.spec.js
+++ b/test/server/spec/lib/templates.spec.js
@@ -310,6 +310,34 @@ describe("lib/templates", function () {
       });
     });
 
+    describe("env file", function () {
+      var instance;
+
+      beforeEach(function () {
+        base.mockFs({
+          "extracted/templates": {
+            "{{_env}}": "---"  // Use token name per our guidelines
+          }
+        });
+
+        instance = new Templates({
+          src: "",
+          dest: "dest",
+          data: base.addPromptDefaults() // Always get these from prompts
+        });
+        _process = instance.process.bind(instance);
+      });
+
+      it("supports .env file template", function (done) {
+        _process(function (err) {
+          if (err) { return void done(err); }
+
+          expect(base.fileRead("dest/.env")).to.equal("---");
+          done();
+        });
+      });
+    });
+
     describe("basic templates", function () {
       var basicTemplates;
 


### PR DESCRIPTION
In order to template env files in the same manner as other special dot files