### PR TITLE
Feature: Customizable templates filter

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,14 @@
 History
 =======
 
+## Unreleased
+
+* Add `_templatesFilter` default derived special variable support.
+  [#4](https://github.com/FormidableLabs/denim/issues/4)
+* Change internal `.gitignore` default filtering to use the resolved path name
+  (e.g., `"foo/bar.txt"`) instead of unexpanded template path (e.g.,
+  `"{{varForFoo}}/bar.txt"`).
+
 ## 0.0.3
 
 * Publish `test/` for other project usage.

--- a/README.md
+++ b/README.md
@@ -179,12 +179,12 @@ in `denim.js` configuration files. A brief list:
     * `_templatesDir` (`"templates"`): The directory root of the templates to
       use during inflation.
     * `_templatesFilter` (_a noop function_): A function with the signature
-      `(filePath, included)` where `filePath` is the full, resolved path to
-      a file, and `included` is a boolean indicating whether or not denim would
-      ordinarily include it (e.g., it is not excluded by the `.gitignore`). An
-      overriding function should return `true` or `false` based on custom logic
-      and can optionally use the `included` parameter from denim's default
-      logic.
+      `(filePath, included)` where `filePath` is the resolved path to a file
+      (relative to templates directory), and `included` is a boolean indicating
+      whether or not denim would ordinarily include it (e.g., it is not excluded
+      by the `.gitignore`). An overriding function should return `true` or
+      `false` based on custom logic and can optionally use the `included`
+      parameter from denim's default logic.
 * _File naming helpers_
     * `_gitignore` (`".gitignore"`)
     * `_npmignore` (`".npmignore"`)

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A lightweight, npm-based template engine.
   - [Automating Prompts](#automating-prompts)
 - [Template Modules](#template-modules)
   - [Templates Module Data](#templates-module-data)
+    - [Special Variables](#special-variables)
     - [Imports and Dependencies](#imports-and-dependencies)
     - [User Prompts](#user-prompts)
     - [Derived Data](#derived-data)
@@ -168,6 +169,27 @@ module.exports = {
 
 Note that `denim` requires `destination` output directories to not exist
 before writing for safety and initialization sanity.
+
+#### Special Variables
+
+There are several default data fields provided by denim that can be overridden
+in `denim.js` configuration files. A brief list:
+
+* _Control_
+    * `_templatesDir` (`"templates"`): The directory root of the templates to
+      use during inflation.
+    * `_templatesFilter` (_a noop function_): A function with the signature
+      `(filePath, included)` where `filePath` is the full, resolved path to
+      a file, and `included` is a boolean indicating whether or not denim would
+      ordinarily include it (e.g., it is not excluded by the `.gitignore`). An
+      overriding function should return `true` or `false` based on custom logic
+      and can optionally use the `included` parameter from denim's default
+      logic.
+* _File naming helpers_
+    * `_gitignore` (`".gitignore"`)
+    * `_npmignore` (`".npmignore"`)
+    * `_npmrc` (`".npmrc"`):
+    * `_eslintrc` (`".eslintrc"`)
 
 #### Imports and Dependencies
 

--- a/README.md
+++ b/README.md
@@ -179,11 +179,11 @@ in `denim.js` configuration files. A brief list:
     * `_templatesDir` (`"templates"`): The directory root of the templates to
       use during inflation.
     * `_templatesFilter` (_a noop function_): A function with the signature
-      `(filePath, included)` where `filePath` is the resolved path to a file
-      (relative to templates directory), and `included` is a boolean indicating
+      `(filePath, isIncluded)` where `filePath` is the resolved path to a file
+      (relative to templates dir), and `isIncluded` is a boolean indicating
       whether or not denim would ordinarily include it (e.g., it is not excluded
       by the `.gitignore`). An overriding function should return `true` or
-      `false` based on custom logic and can optionally use the `included`
+      `false` based on custom logic and can optionally use the `isIncluded`
       parameter from denim's default logic.
 * _File naming helpers_
     * `_gitignore` (`".gitignore"`)

--- a/lib/prompts.js
+++ b/lib/prompts.js
@@ -30,6 +30,19 @@ var DEFAULTS = {
     // Directory containing templates
     _templatesDir: function (data, cb) { cb(null, "templates"); },
 
+    // Filter function for inclusion of resolved template files.
+    //
+    // Should call back with a function of the signature `(filePath, included)`
+    // where the parameters are:
+    // - `filePath`: resolved filepath of a template file
+    // - `included`: boolean indicating if denim default logic would include
+    // - return value: a boolean w/ `true` for "keep", `false` for "exclude"
+    _templatesFilter: function (data, cb) {
+      cb(null, function (filePath, included) {
+        return included; // Simple proxy default included value.
+      });
+    },
+
     // `.npmignore` and `.gitignore` need to be proxied as a template to avoid
     //  NPM losing dev files in `init/` when uploading and executing `npm pack`
     // so we provide them by default here.

--- a/lib/prompts.js
+++ b/lib/prompts.js
@@ -32,14 +32,14 @@ var DEFAULTS = {
 
     // Filter function for inclusion of resolved template files.
     //
-    // Should call back with a function of the signature `(filePath, included)`
+    // Should call back with a function of the signature `(filePath, isIncluded)`
     // where the parameters are:
     // - `filePath`: resolved filepath of a template file
-    // - `included`: boolean indicating if denim default logic would include
+    // - `isIncluded`: boolean indicating if denim default logic would include
     // - return value: a boolean w/ `true` for "keep", `false` for "exclude"
     _templatesFilter: function (data, cb) {
-      cb(null, function (filePath, included) {
-        return included; // Simple proxy default included value.
+      cb(null, function (filePath, isIncluded) {
+        return isIncluded; // Simple proxy default included value.
       });
     },
 

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -279,6 +279,9 @@ Templates.prototype.load = function (callback) {
     }],
 
     filterTemplates: ["templatesDir", "walkTemplates", "loadIgnore", function (results, cb) {
+      // Get filter function.
+      var templatesFilter = self.data._templatesFilter;
+
       // Get ignore filter (if any).
       var ignoreSrc = (results.loadIgnore || "").toString();
       if (!ignoreSrc) {
@@ -288,8 +291,14 @@ Templates.prototype.load = function (callback) {
       // Have ignores. Process and filter.
       var gitignore = ignoreParser.compile(ignoreSrc);
       var filtered = results.walkTemplates.filter(function (stat) {
-        var relPath = path.relative(results.templatesDir, stat.path);
-        return gitignore.accepts(relPath);
+        // Get relative, resolved path.
+        var relPath = path.relative(results.templatesDir, stat.resolvedPath);
+
+        // Default include algorithm.
+        var included = gitignore.accepts(relPath);
+
+        // Push to overridable filter function.
+        return templatesFilter(relPath, included);
       });
 
       cb(null, filtered);

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -295,10 +295,10 @@ Templates.prototype.load = function (callback) {
         var relPath = path.relative(results.templatesDir, stat.resolvedPath);
 
         // Default include algorithm.
-        var included = gitignore.accepts(relPath);
+        var isIncluded = gitignore.accepts(relPath);
 
         // Push to overridable filter function.
-        return templatesFilter(relPath, included);
+        return templatesFilter(relPath, isIncluded);
       });
 
       cb(null, filtered);

--- a/test/server/spec/bin/denim.js
+++ b/test/server/spec/bin/denim.js
@@ -131,11 +131,11 @@ describe("bin/" + SCRIPT, function () {
         }
       })
         .replace("\"TOKEN_TEMPLATES_FILTER\"", function (data, cb) {
-          cb(null, function (filePath, included) {
+          cb(null, function (filePath, isIncluded) {
               // Start with excludes...
             return filePath.indexOf("one/") !== 0 &&  // Remove anything starting with "one/"
               filePath !== "two/nuke.txt" &&          // Exact file path exclusion
-              included                                // Default
+              isIncluded                              // Default
               ||
               // Then, unconditional includes that override...
               filePath === "two/alsoignored.txt";     // Override gitignore to include

--- a/test/server/spec/lib/prompts.spec.js
+++ b/test/server/spec/lib/prompts.spec.js
@@ -154,6 +154,7 @@ describe("lib/prompts", function () {
     runStub.yields("destination");
 
     async.series([
+      // The basics.
       promptsWithData({
         derived: {
           foo: function (data, cb) { cb(null, "foo"); },
@@ -162,6 +163,17 @@ describe("lib/prompts", function () {
       }, function (data) {
         expect(norm(data)).to.deep.equal(addDefaults({ foo: "foo", bar: "bar" }));
       }),
+      // Override special function-based variables.
+      promptsWithData({
+        derived: {
+          _templatesFilter: function (data, cb) { cb(null, function () { return true; }); }
+        }
+      }, function (data) {
+        expect(norm(data)).to.deep.equal(addDefaults({
+          _templatesFilter: function () { return true; }
+        }));
+      }),
+      // Deferred resolutions.
       promptsWithData({
         derived: {
           deferred: function (data, cb) {

--- a/test/server/spec/lib/prompts.spec.js
+++ b/test/server/spec/lib/prompts.spec.js
@@ -5,7 +5,6 @@ var async = require("async");
 var Prompt = require("inquirer/lib/prompts/base");
 var prompts = require("../../../../lib/prompts");
 var base = require("../base.spec");
-var addDefaults = base.addPromptDefaults.bind(base);
 
 // Helpers
 /**
@@ -49,6 +48,23 @@ var promptsWithData = function (init, setupFn, assertFn) {
   };
 };
 
+/**
+ * We clone functions in mocking configs which makes deep comparisons fail.
+ * This method mutates the final data object to be more "comparable" by
+ * doing things like stringifying functions.
+ *
+ * @param {Object}    data  data to compared
+ * @returns {Object}        normalized data
+ */
+var norm = function (data) {
+  return _.mapValues(data, function (val) {
+    return _.isFunction(val) ? val.toString() : val;
+  });
+};
+
+var addDefaults = function (data) {
+  return norm(base.addPromptDefaults(data));
+};
 
 describe("lib/prompts", function () {
   var runStub;
@@ -110,13 +126,13 @@ describe("lib/prompts", function () {
 
     async.series([
       promptsWithData({}, function (data) {
-        expect(data).to.deep.equal(addDefaults());
+        expect(norm(data)).to.deep.equal(addDefaults());
       }),
       promptsWithData({ prompts: [] }, function (data) {
-        expect(data).to.deep.equal(addDefaults());
+        expect(norm(data)).to.deep.equal(addDefaults());
       }),
       promptsWithData({ prompts: {}, derived: {} }, function (data) {
-        expect(data).to.deep.equal(addDefaults());
+        expect(norm(data)).to.deep.equal(addDefaults());
       })
     ], done);
   });
@@ -130,7 +146,7 @@ describe("lib/prompts", function () {
       prompts: { name: { message: "Name" } }
     }, function (data) {
       expect(runStub).to.not.be.called;
-      expect(data).to.deep.equal(addDefaults({ name: "Bob" }));
+      expect(norm(data)).to.deep.equal(addDefaults({ name: "Bob" }));
     })(done);
   });
 
@@ -144,7 +160,7 @@ describe("lib/prompts", function () {
           bar: function (data, cb) { cb(null, "bar"); }
         }
       }, function (data) {
-        expect(data).to.deep.equal(addDefaults({ foo: "foo", bar: "bar" }));
+        expect(norm(data)).to.deep.equal(addDefaults({ foo: "foo", bar: "bar" }));
       }),
       promptsWithData({
         derived: {
@@ -155,7 +171,7 @@ describe("lib/prompts", function () {
           }
         }
       }, function (data) {
-        expect(data).to.deep.equal(addDefaults({ deferred: "foo" }));
+        expect(norm(data)).to.deep.equal(addDefaults({ deferred: "foo" }));
       })
     ], done);
   });
@@ -204,7 +220,7 @@ describe("lib/prompts", function () {
           .onCall(0).yields("2016")
           .onCall(1).yields("destination");
       }, function (data) {
-        expect(data).to.deep.equal(addDefaults({ licenseDate: "2016" }));
+        expect(norm(data)).to.deep.equal(addDefaults({ licenseDate: "2016" }));
       }),
 
       promptsWithData({
@@ -219,7 +235,7 @@ describe("lib/prompts", function () {
           .onCall(1).yields("The Whiz Bang")
           .onCall(2).yields("destination");
       }, function (data) {
-        expect(data).to.deep.equal(addDefaults({
+        expect(norm(data)).to.deep.equal(addDefaults({
           packageName: "whiz-bang",
           packageDescription: "The Whiz Bang"
         }));
@@ -244,7 +260,7 @@ describe("lib/prompts", function () {
         .onCall(0).yields("2016")
         .onCall(1).yields("destination");
     }, function (data) {
-      expect(data).to.deep.equal(addDefaults({
+      expect(norm(data)).to.deep.equal(addDefaults({
         year: "2016",
         reverseYear: "6102",
         independent: "independent"
@@ -266,7 +282,7 @@ describe("lib/prompts", function () {
         .onCall(0).yields("prompts")
         .onCall(1).yields("destination");
     }, function (data) {
-      expect(data).to.deep.equal(addDefaults({
+      expect(norm(data)).to.deep.equal(addDefaults({
         foo: "prompts"
       }));
     })(done);


### PR DESCRIPTION
* Add `_templatesFilter` function to include / exclude / pass-through to existing denim logic each relative, resolved file path of the templates.
* Adds README section summary for just the special variables.
* Changes previous behavior to filter based on **resolved** file path (`foo/text.txt`) rather than **template** file path (`{{aVarTheProducesFoo}}/text.txt`). This seems like the more correct behavior as the `.gitignore` default behavior should really apply to resolved names.. But it _does_ change how things were filtered in the past so it's semver `MAJOR`. Fortunately we're in `0.0.x` current number, so we'll target a `0.x.0` release.

Closes #4 

/cc @kenwheeler @imranolas 