### PR TITLE
BUG: Handle negated gitignore patterns.

### DIFF
--- a/lib/templates.js
+++ b/lib/templates.js
@@ -297,13 +297,19 @@ Templates.prototype.load = function (callback) {
         return void cb(null, results.walkTemplates);
       }
 
-      // Have ignores. Process and filter.
+      var ignored = mm(
+        results.walkTemplates.map(function (stat) {
+          return path.relative(results.templatesDir, stat.resolvedPath);
+        }),
+        ignoreGlobs
+      );
+
       var filtered = results.walkTemplates.filter(function (stat) {
         // Get relative, resolved path.
         var relPath = path.relative(results.templatesDir, stat.resolvedPath);
 
         // Default include algorithm.
-        var isIgnored = mm.any(relPath, ignoreGlobs);
+        var isIgnored = _.includes(ignored, relPath);
 
         // Push to overridable filter function.
         return templatesFilter(relPath, !isIgnored);

--- a/test/server/spec/bin/denim.js
+++ b/test/server/spec/bin/denim.js
@@ -194,12 +194,13 @@ describe("bin/" + SCRIPT, function () {
       });
     }));
 
-    // Correctly applies git ignore rules.
+    // Correctly applies git ignore rules, even with negated expressions
     // Bug: https://github.com/FormidableLabs/denim/issues/9
+    // Bug: https://github.com/FormidableLabs/denim/issues/11
     it("allows npmignore, npmrc when npm is in gitignore", stdioWrap(function (done) {
       var stubs = mockFlow({
         "templates": {
-          ".gitignore": ".npm\n",
+          ".gitignore": "!nomatch\n.npm\n",
           ".npmignore": "holla",
           ".npmrc": "// holla too",
           ".npm": {


### PR DESCRIPTION
Use multimatch-style globbing to correctly handle negated gitignore patterns. Fixes #11